### PR TITLE
Add basic header parsing of the email message

### DIFF
--- a/lib/mail_parser.ex
+++ b/lib/mail_parser.ex
@@ -16,6 +16,7 @@ defmodule MailParser do
     version: version
 
   alias __MODULE__.Attachment
+  alias __MODULE__.Header
 
   @doc """
   Parses a string containing a RFC5322 raw message and extracts all nested
@@ -32,4 +33,7 @@ defmodule MailParser do
   """
   @spec extract_nested_attachments(String.t()) :: {:ok, [Attachment.t()]} | :error
   def extract_nested_attachments(_raw_message), do: :erlang.nif_error(:nif_not_loaded)
+
+  @spec extract_header(String.t()) :: {:ok, [Header.t()]} | :error
+  def extract_header(_raw_message), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/mail_parser/header.ex
+++ b/lib/mail_parser/header.ex
@@ -1,0 +1,16 @@
+defmodule MailParser.Header do
+  @moduledoc """
+  A message header.
+  """
+
+  @type t :: %__MODULE__{
+          subject: String.t() | nil,
+          from: String.t() | nil,
+          to: String.t(),
+          cc: String.t() | nil,
+          bcc: String.t() | nil,
+          date: String.t() | nil
+        }
+
+  defstruct [:subject, :from, :to, :cc, :bcc, :date]
+end

--- a/native/mail_parser_nif/Cargo.lock
+++ b/native/mail_parser_nif/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashify"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f208758247e68e239acaa059e72e4ce1f30f2a4b6523f19c1b923d25b7e9cceb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,9 +36,12 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "mail-parser"
-version = "0.8.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4158a1c18963244e083888b21465846dfb68d6170850ed1ab4742edd57c9d47"
+checksum = "187a2b93c4c8c32f552ee06c2d99915e575de2fc7e04b07891c9edfee5b8edd6"
+dependencies = [
+ "hashify",
+]
 
 [[package]]
 name = "mail_parser_nif"

--- a/native/mail_parser_nif/Cargo.toml
+++ b/native/mail_parser_nif/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-mail-parser = { version = "0.8.2", default-features = false }
+mail-parser = { version = "0.10.2", default-features = false }
 rustler = "0.29.1"
 
 [profile.release]

--- a/native/mail_parser_nif/src/lib.rs
+++ b/native/mail_parser_nif/src/lib.rs
@@ -1,4 +1,4 @@
-use mail_parser::{Message, MessagePart, MimeHeaders};
+use mail_parser::{Message, MessageParser, MessagePart, MimeHeaders};
 use rustler::{Atom, Binary, Env, Error, NifResult, NifStruct, OwnedBinary, Term};
 use rustler::{Decoder, Encoder};
 
@@ -14,6 +14,17 @@ struct Attachment {
     name: String,
     content_type: Option<String>,
     content_bytes: ContentBytes,
+}
+
+#[derive(Clone, Debug, NifStruct)]
+#[module = "MailParser.Header"]
+struct Header {
+    subject: String,
+    from: String,
+    to: String,
+    cc: Option<String>,
+    bcc: Option<String>,
+    date: String,
 }
 
 impl From<&MessagePart<'_>> for Attachment {
@@ -69,13 +80,61 @@ fn get_attachments(message: &Message) -> Vec<Attachment> {
         })
         .collect()
 }
+fn get_header(message: &Message) -> Header {
+    let subject = message.subject().unwrap_or("untitled").to_string();
+    let from = message
+        .from()
+        .and_then(|from_vec| from_vec.first())
+        .and_then(|address| address.address())
+        .map(|addr| addr.to_string())
+        .unwrap_or_else(|| String::from(""));
+
+    let to = message
+        .to()
+        .and_then(|to_vec| to_vec.first())
+        .and_then(|address| address.address())
+        .map(|addr| addr.to_string())
+        .unwrap_or_else(|| String::from(""));
+
+    let cc = message
+        .cc()
+        .and_then(|cc_vec| cc_vec.first())
+        .and_then(|address| address.address())
+        .map(|addr| addr.to_string());
+
+    let bcc = message
+        .bcc()
+        .and_then(|bcc_vec| bcc_vec.first())
+        .and_then(|address| address.address())
+        .map(|addr| addr.to_string());
+    let date = message.date().unwrap().to_rfc3339();
+    Header {
+        subject: subject,
+        from: from,
+        to: to,
+        cc: cc,
+        bcc: bcc,
+        date: date,
+    }
+}
 
 #[rustler::nif]
 fn extract_nested_attachments(raw_message: &str) -> NifResult<(Atom, Vec<Attachment>)> {
-    match Message::parse(raw_message.as_bytes()) {
+    match MessageParser::default().parse(raw_message.as_bytes()) {
         Some(message) => Ok((atoms::ok(), get_attachments(&message))),
         None => Err(Error::Atom("error")),
     }
 }
 
-rustler::init!("Elixir.MailParser", [extract_nested_attachments]);
+#[rustler::nif]
+fn extract_header(raw_message: &str) -> NifResult<(Atom, Header)> {
+    match MessageParser::default().parse(raw_message.as_bytes()) {
+        Some(message) => Ok((atoms::ok(), get_header(&message))),
+        None => Err(Error::Atom("error")),
+    }
+}
+
+rustler::init!(
+    "Elixir.MailParser",
+    [extract_nested_attachments, extract_header]
+);

--- a/test/mail_parser_test.exs
+++ b/test/mail_parser_test.exs
@@ -23,6 +23,20 @@ defmodule MailParserTest do
     assert pdf_content_bytes == File.read!("test/fixtures/sample.pdf")
   end
 
+  test "extracts headers from raw message" do
+    raw_message = File.read!("test/fixtures/example.txt")
+
+    assert {:ok,
+            %MailParser.Header{
+              bcc: nil,
+              cc: "Arno.Nuehm@example.com",
+              date: "2022-05-17T08:05:04Z",
+              from: "joe@example.com",
+              subject: "Bestellung 0340/2022",
+              to: "max.mustermann@example.com"
+            }} = MailParser.extract_header(raw_message)
+  end
+
   test "returns error if parsing fails" do
     assert :error = MailParser.extract_nested_attachments("")
   end


### PR DESCRIPTION
Hi

I've added basic email header parsing to your library. Would you like to merge it into your code? Or do you prefer I create a new hex project so that this one is for extracting attachments only?

Best,
Michael